### PR TITLE
hooks: disable progress on aws s3 cp

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -29,7 +29,7 @@ cache_key="$BUILDKITE_ORGANIZATION_SLUG/$BUILDKITE_PIPELINE_NAME/$cache_file"
 echo -e "ASDF 🔍 Locating cache: $cache_key"
 if aws s3api head-object --bucket "$BUILDKITE_PLUGIN_ASDF_CACHE_BUCKET_NAME" --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "$BUILDKITE_PLUGIN_ASDF_CACHE_REGION_NAME" --key "$cache_key"; then
   echo -e "ASDF 🔥 Cache hit: $cache_key"
-  aws s3 cp --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "$BUILDKITE_PLUGIN_ASDF_CACHE_REGION_NAME" "s3://$BUILDKITE_PLUGIN_ASDF_CACHE_BUCKET_NAME/$cache_key" "$HOME/"
+  aws s3 cp --no-progress --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "$BUILDKITE_PLUGIN_ASDF_CACHE_REGION_NAME" "s3://$BUILDKITE_PLUGIN_ASDF_CACHE_BUCKET_NAME/$cache_key" "$HOME/"
   pushd "$HOME" || exit
   rm -rf .asdf
   bsdtar xzf "$cache_file"
@@ -42,7 +42,7 @@ else
   pushd "$HOME" || exit
   bsdtar cfz "$cache_file" .asdf
   popd || exit
-  aws s3 cp --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "$BUILDKITE_PLUGIN_ASDF_CACHE_REGION_NAME" "$HOME/$cache_file" "s3://$BUILDKITE_PLUGIN_ASDF_CACHE_BUCKET_NAME/$cache_key"
+  aws s3 cp --no-progress --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "$BUILDKITE_PLUGIN_ASDF_CACHE_REGION_NAME" "$HOME/$cache_file" "s3://$BUILDKITE_PLUGIN_ASDF_CACHE_BUCKET_NAME/$cache_key"
 fi
 
 unset AWS_SHARED_CREDENTIALS_FILE


### PR DESCRIPTION
The caches are large, meaning the progress on cache downloads take up a huge portion of build logs